### PR TITLE
Implement a proper command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,66 @@ Well, most likely you are treading on the path's of the ancients. Use their know
 They have nigthly dumps of their database which contains information of all the star systems the community has discovered so far.
 
 ## What you'll get
-This python 3 program uses these databases (which one is described in the source-code) to find stars to jump to between the system you are in (or near) right now and the system you want to jump to.
+This python 3 program uses these databases (which one is described below) to find stars to jump to between the system you are in (or near) right now and the system you want to jump to.
 The program is NOT designed to find the shortest path, but the most economic path, needing the fewest boosted jumps possible.
 Just put the necessary information (start- and end-coordinates, your jump-ranges and a bit more) at the beginning of the < gap_jumper.py > file and then call the same on the command-line.
 
-## ATTENTION
+# Usage
+
+```
+$ python gap_jumper.py -h
+usage: gap_jumper.py [-h] --range LY [--range-on-fumes LY]
+                     --startcoords X Y Z --destcoords X Y Z
+                     [--cached] [--starsfile FILE] [--max-tries N]
+
+You want to directly cross from one spiral arm of the galaxy to
+another but there is this giant gap between them? This program helps
+you to find a way. Default behavior is to use the EDSM API to load
+stars on-demand. Use the --starsfile option if you have downloaded
+the systemsWithCoordinates.json nigthly dump from EDSM.
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --range LY, -r LY     Ship range with a full fuel tank (required)
+  --range-on-fumes LY, -rf LY
+                        Ship range with fuel for one jump (defaults
+                        equal to range)
+  --startcoords X Y Z, -s X Y Z
+                        Galactic coordinates to start routing from
+  --destcoords X Y Z, -d X Y Z
+                        Galactic coordinates of target destination
+  --cached              Reuse nodes data from previous run
+  --starsfile FILE      Path to EDSM system coordinates JSON file
+  --max-tries N, -N N   How many times to shuffle and reroute before
+                        returning best result (default 23)
+```
+
+## Examples
+
+You will need to obtain the x/y/z galactic coordinates of your start and destination points. These can be obtained approximately from the in-game galaxy map, or by looking up a system name in EDSM. For these examples, let's consider a route from Beagle Point to Semotus Beacon.
+
+  - Beagle Point: -1111.56 / -134.22 / 65269.75
+  - Oevasy SG-Y d0 (Semotus Beacon): -1502.16 / -2.63 / 65630.17
+
+Basic usage:
+
+    python gap_jumper.py --range 60 --startcoords -1111.56 -134.22 65269.75 
+        --destcoords -1502.16 -2.63 65630.17
+
+The above invocation will query the EDSM API for the necessary system coordinates data and compute a route from the start to the destination for a ship with a 60 LY base range, using a minimum number of boosted jumps. 
+
+Advanced usage:
+
+    python gap_jumper.py -r 60 -rf 63.5 -s -1111.56 -134.22 65269.75 
+        -d -1502.16 -2.63 65630.17 --starsfile systems.json -N 40
+
+The above example uses the abbreviated options syntax. Here we specify a ship with base range of 60 LY and also specify a "range on fumes". The computed route will recommend reduced-fuel jumps when possible to save synth materials. Additionally, this example assumes that the `systemsWithCoordinates.json` file has been downloaded from [EDSM Nightly Dumps](https://www.edsm.net/en/nightly-dumps) as `systems.json`, and will make 40 randomized attempts to find an optimal route. 
+
+During each run, the data for the set of stars considered is cached in the local directory. The option `--cached` makes use of this cache instead of querying EDSM or attempting to open the systems.json file. This is much faster if you want to adjust your search parameters within the same region of space.
+
+# ATTENTION
 The search in the database is inefficient and will take some time. But the void is patient.
 
-Also, please read the comments especially in < gap_jumper.py > for additional information on how to use this program.
-I may or may not provide a gui at a later time.
+Please note that for long routes (about 1000 LY or more) the default mode will exceed EDSM's rate limits and fail to fetch all the required stars. A future version will throttle and retry the queries so that the data is eventually retrieved. 
+
+Discussion of this program, and further description of the motivations and approach, can be found in the Frontier Forum thread: [The ancient automated pathfinder-stations](https://forums.frontier.co.uk/threads/the-ancient-automated-pathfinder-stations.475668/). Additional information can be found in the source code comments, especially in 

--- a/gap_jumper.py
+++ b/gap_jumper.py
@@ -36,7 +36,7 @@ import find_systems_offline as off
 import find_systems_online as on
 import find_route as fr
 import pickle
-
+import argparse
 
 ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
 ## ## ## ## ##                            ## ## ## ## ##
@@ -46,6 +46,7 @@ import pickle
 
 # start- and end-coordinates from in-game starmap
 # Below you can see an example
+
 start_coords = {'x': 15015.0, 'y': -22.0, 'z': -7701.0}
 end_coords = {'x': 17021.0, 'y': -15.0, 'z': -9677.0}
 
@@ -77,12 +78,29 @@ coordinates_file ='systemsWithCoordinates.json'
 # the found systems file will be stored, too.
 path = ''
 
+## Beginning of program execution when run from the command line
+if __name__ == "__main__":
 
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-## ## ## ##  Outcomment below if the stars for  ## ## ##
-## ## ## ##  a new path shall be found for the  ## ## ## 
-## ## ## ##  first time.                        ## ## ##
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+    parser = argparse.ArgumentParser(
+        description="""You want to directly cross from one spiral arm of the
+        galaxy to another but there is this giant gap between them?
+        This program helps you to find a way.
+        
+        Default behavior is to use the EDSM API to load stars on-demand. Use
+        the --starsfile option if you have downloaded the systemsWithCoordinates.json
+        nigthly dump from EDSM.""",
+        epilog="See README.md for further information.")
+    parser.add_argument('--cached','-c', action='store_true', help="Reuse nodes data from previous run")
+    parser.add_argument('--starsfile','-s',action='store', metavar='FILE',
+                        help="Path to EDSM system coordinates JSON file")
+    parser.add_argument('--range','-r', action='store', metavar='LY', required=True, type=float, 
+                        help="Ship range with a full fuel tank (required)")
+    parser.add_argument('--range-on-fumes','-rf', action='store', metavar='LY', type=float)
+    args = parser.parse_args()
+    
+    if not args.range_on_fumes:
+        args.range_on_fumes = args.range+0.01
+    jumpable_distances = [0] + [x*y for x in [1, 1.25, 1.5, 2.0] for y in [args.range, args.range_on_fumes]]
 
 # After the program was executed once, the database with all found stars 
 # for a given route and the corresponding notes are stored.
@@ -98,64 +116,48 @@ path = ''
 # NOT having a comment around all in connection with af.create_nodes()
 # 4.: The rest of the program is the same.
 
-#filename = path + 'stars'
-#with open(filename, 'rb') as f:
-	#stars = pickle.load(f)
+## Code path: load previously saved nodes
+    if args.cached:
+        filename = path + 'stars_on'
+        with open(filename, 'rb') as f:
+            stars = pickle.load(f)
 
-#filename = path + 'all_nodes'
-#with open(filename, 'rb') as f:
-	#pristine_nodes = pickle.load(f)
+        filename = path + 'all_nodes'
+        with open(filename, 'rb') as f:
+            pristine_nodes = pickle.load(f)
 
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-## ## ## ##  Outcomment above if the stars for  ## ## ##
-## ## ## ##  a new path shall be found for the  ## ## ## 
-## ## ## ##  first time.                        ## ## ##
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+## Code path: load stars from API or JSON
+    else:
+        if not args.starsfile:
+            stars = on.find_systems_online(start_coords, end_coords)
+        else:
+            infile = args.starsfile
+            stars = off.find_systems_offline(start_coords, end_coords, infile)
 
-
-
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-## ## ## ##  REMOVE comments below if the stars ## ## ##
-## ## ## ##  for a new path shall be found for  ## ## ## 
-## ## ## ##  the first time.                    ## ## ##
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-
-if not search_offline:
-	stars = on.find_systems_online(start_coords, end_coords)
-else:
-	infile = path + coordinates_file
-	stars = off.find_systems_offline(start_coords, end_coords, infile)
-
-filename = path + 'stars_on'
-with open(filename, 'wb') as f:
-	pickle.dump(stars, f)
+        filename = path + 'stars_on'
+        with open(filename, 'wb') as f:
+            pickle.dump(stars, f)
 
 
-pristine_nodes = af.create_nodes(stars, jumpable_distances)
+        pristine_nodes = af.create_nodes(stars, jumpable_distances)
 
-filename = path + 'all_nodes'
-with open(filename, 'wb') as f:
-	pickle.dump(pristine_nodes, f)
-
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
-## ## ## ##  REMOVE comments above if the stars ## ## ##
-## ## ## ##  for a new path shall be found for  ## ## ## 
-## ## ## ##  the first time.                    ## ## ##
-## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ## ##
+        filename = path + 'all_nodes'
+        with open(filename, 'wb') as f:
+            pickle.dump(pristine_nodes, f)
 
 
 
-start_star, end_star = af.find_closest(stars, start_coords, end_coords)
+    start_star, end_star = af.find_closest(stars, start_coords, end_coords)
 
-fewest_jumps_jumper = fr.find_path(max_tries, stars, start_star, end_star, \
-																pristine_nodes)
+    fewest_jumps_jumper = fr.find_path(max_tries, stars, start_star, end_star, \
+                                                                    pristine_nodes)
 
-print()
-print("Start at: ", start_star)
-print("  End at: ", end_star)
-print("\nNumber of stars considered: ", len(stars))
+    print()
+    print("Start at: ", start_star)
+    print("  End at: ", end_star)
+    print("\nNumber of stars considered: ", len(stars))
 
-af.print_jumper_information(pristine_nodes, fewest_jumps_jumper)
+    af.print_jumper_information(pristine_nodes, fewest_jumps_jumper)
 
 
 


### PR DESCRIPTION
In this branch I have done two things: use the `argparse` library to implement parsing of options passed on the command line, and add usage documentation to the README.md file. Now users will no longer have to modify source code files to use the program. 

Not done here, but suggested next steps, would include:

  - add EDSM lookup of system names so users can input those instead of x/y/z coordinates
  - add rate-limit awareness to EDSM API calls so all needed cubes are successfully retrieved
  - develop a scheme for caching previously-retrieved EDSM results

If this sounds like reasonable next steps to you, I will work on those next. 